### PR TITLE
feat: redesign documentation hub

### DIFF
--- a/docs/analytics/auth.html
+++ b/docs/analytics/auth.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Guía de Autenticación - Analytics Suite</title>
+    <style>
+        body {
+            font-family: "Segoe UI", sans-serif;
+            margin: 2rem auto;
+            max-width: 800px;
+            line-height: 1.6;
+            color: #1f2933;
+        }
+        h1, h2 {
+            color: #111827;
+        }
+        pre {
+            background: #f3f4f6;
+            padding: 1rem;
+            border-radius: 8px;
+            overflow-x: auto;
+        }
+        code {
+            font-family: "Fira Code", monospace;
+        }
+    </style>
+</head>
+<body>
+    <h1>Guía de Autenticación</h1>
+    <p>Utiliza la autenticación OAuth 2.0 con el flujo <em>Client Credentials</em> para solicitar tokens.</p>
+    <h2>Solicitud de token</h2>
+    <pre><code>POST /oauth/token
+Host: analytics.rentasoft.com
+Content-Type: application/json
+
+{
+  "client_id": "tu-client-id",
+  "client_secret": "tu-client-secret",
+  "audience": "analytics-api",
+  "grant_type": "client_credentials"
+}
+</code></pre>
+    <p>El token tendrá una vigencia de 1 hora. Renueva el token antes de su expiración.</p>
+</body>
+</html>

--- a/docs/analytics/metrics.md
+++ b/docs/analytics/metrics.md
@@ -1,0 +1,35 @@
+# API de Métricas - Analytics Suite
+
+La API de Métricas ofrece indicadores en tiempo real para tableros y reportes personalizados.
+
+## Características
+
+- Estadísticas de uso minuto a minuto.
+- Filtros por producto, canal y segmento de clientes.
+- Entrega de datos en formato JSON y CSV.
+
+## Autenticación
+
+1. Solicita un `client_id` y `client_secret` al equipo de cuentas.
+2. Obtén un token OAuth 2.0 con el flujo Client Credentials en `POST /oauth/token`.
+3. Envía el token en el encabezado `Authorization` de cada solicitud.
+
+## Endpoints clave
+
+| Endpoint | Descripción |
+|----------|-------------|
+| `/metrics/summary` | Indicadores principales agregados. |
+| `/metrics/timeseries` | Serie temporal de métricas personalizadas. |
+| `/exports` | Descarga CSV con métricas crudas. |
+
+## Ejemplo de petición
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" \
+     "https://analytics.rentasoft.com/api/v1/metrics/summary?product=mrturno"
+```
+
+## Recursos relacionados
+
+- Documentación de autenticación avanzada en `docs/analytics/auth.html`.
+- Plantillas de tableros en el repositorio interno de BI.

--- a/docs/mt_api_dev/overview.md
+++ b/docs/mt_api_dev/overview.md
@@ -1,0 +1,41 @@
+# API de Desarrolladores de MrTurno
+
+La API de desarrolladores de **MrTurno** permite integrar el motor de reservas con aplicaciones externas.
+
+## Recursos principales
+
+- `/branches` – administra sucursales y horarios de atención.
+- `/services` – consulta la oferta de servicios disponibles por sucursal.
+- `/bookings` – crea, reprograma o cancela turnos.
+
+## Autenticación
+
+Utiliza tokens **JWT** generados desde el panel administrativo de MrTurno. Incluye el encabezado:
+
+```
+Authorization: Bearer <token>
+```
+
+## Ejemplo de creación de turno
+
+```http
+POST /bookings HTTP/1.1
+Host: api.mrturno.com
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{
+  "branch_id": "studiocentral",
+  "service_id": "depilacion",
+  "customer": {
+    "name": "Ana",
+    "phone": "+595000000"
+  },
+  "slot": "2024-06-01T14:30:00-04:00"
+}
+```
+
+## Próximos pasos
+
+- Consulta la [referencia HTML](index.html) para un detalle completo de los campos.
+- Revisa los webhooks disponibles en la API de notificaciones.

--- a/documentacion.html
+++ b/documentacion.html
@@ -1,65 +1,277 @@
 <!DOCTYPE html>
 <html lang="es">
-
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Documentación de APIs y Sistemas</title>
+    <title>Centro de Documentación | RENT-A-SOFT-SA</title>
     <link rel="stylesheet" href="styles.css">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
 </head>
-
-<body>
-    <!-- Mobile sidebar toggle button -->
-    <button class="sidebar-toggle" aria-label="Toggle navigation">☰</button>
-    <!-- Left Sidebar Navigation -->
-    <nav class="sidebar">
-        <div class="sidebar-header">
-            <h2>RENT-A-SOFT-SA</h2>
-        </div>
-        <div class="sidebar-nav">
-            <ul>
-                <li><a href="index.html">Inicio</a></li>
-                <li><a href="contact.html">Contacto</a></li>
-                <li><a href="documentacion.html" class="active">Documentación APIs</a></li>
-            </ul>
-        </div>
-    </nav>
-    <header>
-        <nav>
-            <div class="nav-container">
-                <ul class="nav-menu">
-                    <li><a href="index.html" class="nav-link">Inicio</a></li>
-                    <li><a href="contact.html" class="nav-link">Contacto</a></li>
-                    <li><a href="documentacion.html" class="nav-link active">Documentación APIs</a></li>
-                </ul>
+<body class="docs-body">
+    <header class="docs-header">
+        <div class="docs-brand">
+            <span class="brand-accent"></span>
+            <div>
+                <p class="brand-label">RENT-A-SOFT-SA</p>
+                <h1 class="brand-title">Centro de Documentación</h1>
             </div>
+        </div>
+        <nav class="docs-nav">
+            <a href="index.html">Inicio</a>
+            <a href="contact.html">Contacto</a>
         </nav>
     </header>
 
-    <main>
-        <section class="page-header">
-            <div class="container">
-                <h1>Documentación</h1>
-                <p>Bienvenido a la sección de documentación de APIs y sistemas de RENT-A-SOFT-SA.</p>
+    <main class="docs-layout">
+        <aside class="docs-sidebar" aria-label="Listado de productos y APIs">
+            <div class="sidebar-intro">
+                <h2>Biblioteca técnica</h2>
+                <p>Explora nuestras APIs organizadas por producto y accede a su documentación oficial.</p>
             </div>
-        </section>
-        <section class="page-content doc-index">
-            <div class="container">
-                <h2>Documentación de APIs y Sistemas</h2>
-                <p>Selecciona la documentación que deseas consultar:</p>
-                <ul>
-                    <li><a href="docs/mt_api_dev/index.html">API Desarrolladores de MrTurno</a></li>
-                    <!-- Agrega aquí más APIs o sistemas -->
-                </ul>
+            <div id="docs-catalog" class="catalog"></div>
+        </aside>
+
+        <section class="docs-viewer" aria-label="Visor de documentación">
+            <div class="viewer-toolbar">
+                <div>
+                    <p class="viewer-label">Documento activo</p>
+                    <h2 id="viewer-title">Selecciona una API para comenzar</h2>
+                </div>
+                <label class="upload-btn">
+                    Cargar archivo local
+                    <input type="file" id="local-doc" accept=".md,.markdown,.html,.htm">
+                </label>
             </div>
+            <div id="viewer-meta" class="viewer-meta"></div>
+            <article id="doc-content" class="viewer-content">
+                <p class="empty-state">Elige un elemento del listado o carga un archivo <code>.md</code>/<code>.html</code> para visualizarlo aquí.</p>
+            </article>
         </section>
     </main>
-    <footer>
-        <div class="container">
-            <p>&copy; 2024 RENT-A-SOFT-SA. Todos los derechos reservados.</p>
-        </div>
-    </footer>
-    <script src="sidebar.js"></script>
-</body>
 
+    <footer class="docs-footer">
+        <p>&copy; 2024 RENT-A-SOFT-SA. Documentación centralizada para equipos y partners.</p>
+    </footer>
+
+    <script>
+        const documentationCatalog = [
+            {
+                product: 'MrTurno',
+                description: 'Soluciones de reservas y administración de turnos.',
+                apis: [
+                    {
+                        id: 'mrturno-rest',
+                        name: 'API REST para desarrolladores',
+                        summary: 'Endpoints REST para gestionar sucursales, servicios y turnos en tiempo real.',
+                        format: 'md',
+                        path: 'docs/mt_api_dev/overview.md'
+                    },
+                    {
+                        id: 'mrturno-reference',
+                        name: 'Referencia HTML completa',
+                        summary: 'Documento HTML con el detalle de atributos, ejemplos y códigos de respuesta.',
+                        format: 'html',
+                        path: 'docs/mt_api_dev/index.html'
+                    }
+                ]
+            },
+            {
+                product: 'Analytics Suite',
+                description: 'Plataforma de métricas y tableros multi-producto.',
+                apis: [
+                    {
+                        id: 'analytics-metrics',
+                        name: 'API de Métricas',
+                        summary: 'Consulta indicadores agregados y series temporales para tableros de negocio.',
+                        format: 'md',
+                        path: 'docs/analytics/metrics.md'
+                    },
+                    {
+                        id: 'analytics-auth',
+                        name: 'Guía de autenticación',
+                        summary: 'Pasos para generar tokens OAuth 2.0 y asegurar tus integraciones.',
+                        format: 'html',
+                        path: 'docs/analytics/auth.html'
+                    }
+                ]
+            }
+        ];
+
+        const catalogContainer = document.getElementById('docs-catalog');
+        const viewerTitle = document.getElementById('viewer-title');
+        const viewerMeta = document.getElementById('viewer-meta');
+        const docContent = document.getElementById('doc-content');
+        const localDocInput = document.getElementById('local-doc');
+        let activeButton = null;
+
+        function createCatalog() {
+            documentationCatalog.forEach(group => {
+                const section = document.createElement('section');
+                section.className = 'catalog-group';
+
+                const header = document.createElement('header');
+                header.className = 'catalog-group__header';
+                header.innerHTML = `
+                    <h3>${group.product}</h3>
+                    <p>${group.description}</p>
+                `;
+                section.appendChild(header);
+
+                const list = document.createElement('div');
+                list.className = 'catalog-group__items';
+
+                group.apis.forEach(api => {
+                    const button = document.createElement('button');
+                    button.type = 'button';
+                    button.className = 'catalog-item';
+                    button.dataset.path = api.path;
+                    button.dataset.format = api.format;
+                    button.dataset.product = group.product;
+                    button.dataset.name = api.name;
+                    button.dataset.summary = api.summary;
+                    button.dataset.id = api.id;
+                    button.innerHTML = `
+                        <span class="catalog-item__title">${api.name}</span>
+                        <span class="catalog-item__summary">${api.summary}</span>
+                        <span class="catalog-item__format">${api.format.toUpperCase()}</span>
+                    `;
+                    button.addEventListener('click', () => {
+                        loadDocumentation(api, group.product, button);
+                        updateQueryString(api.id);
+                    });
+                    list.appendChild(button);
+                });
+
+                section.appendChild(list);
+                catalogContainer.appendChild(section);
+            });
+        }
+
+        function updateQueryString(id) {
+            const params = new URLSearchParams(window.location.search);
+            params.set('doc', id);
+            const query = params.toString();
+            if (history.replaceState) {
+                history.replaceState(null, '', `${window.location.pathname}?${query}`);
+            }
+        }
+
+        function loadDocumentation(api, productName, buttonElement, isInitialLoad = false) {
+            if (!isInitialLoad) {
+                docContent.innerHTML = '<p class="loading">Cargando documentación…</p>';
+            }
+            viewerTitle.textContent = api.name;
+            viewerMeta.innerHTML = `
+                <span class="meta-item">${productName}</span>
+                <span class="meta-item">Formato ${api.format.toUpperCase()}</span>
+            `;
+
+            fetch(api.path)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('No se pudo obtener el archivo solicitado.');
+                    }
+                    return response.text();
+                })
+                .then(rawContent => {
+                    if (api.format === 'md' || api.path.endsWith('.md') || api.path.endsWith('.markdown')) {
+                        docContent.innerHTML = marked.parse(rawContent);
+                    } else {
+                        const parser = new DOMParser();
+                        const parsed = parser.parseFromString(rawContent, 'text/html');
+                        docContent.innerHTML = parsed.body ? parsed.body.innerHTML : rawContent;
+                    }
+                })
+                .catch(error => {
+                    docContent.innerHTML = `<p class="error-state">${error.message}</p>`;
+                });
+
+            if (activeButton) {
+                activeButton.classList.remove('catalog-item--active');
+            }
+            if (buttonElement) {
+                buttonElement.classList.add('catalog-item--active');
+                activeButton = buttonElement;
+            }
+        }
+
+        function findApiById(id) {
+            for (const group of documentationCatalog) {
+                for (const api of group.apis) {
+                    if (api.id === id) {
+                        return { api, product: group.product };
+                    }
+                }
+            }
+            return null;
+        }
+
+        function handleInitialLoad() {
+            const params = new URLSearchParams(window.location.search);
+            const docId = params.get('doc');
+            if (docId) {
+                const match = findApiById(docId);
+                if (match) {
+                    const button = document.querySelector(`.catalog-item[data-id="${docId}"]`);
+                    loadDocumentation(match.api, match.product, button, true);
+                    if (button) {
+                        button.classList.add('catalog-item--active');
+                        activeButton = button;
+                    }
+                }
+            } else {
+                const firstGroup = documentationCatalog[0];
+                if (firstGroup && firstGroup.apis.length) {
+                    const firstApi = firstGroup.apis[0];
+                    const button = document.querySelector(`.catalog-item[data-id="${firstApi.id}"]`);
+                    loadDocumentation(firstApi, firstGroup.product, button, true);
+                    if (button) {
+                        button.classList.add('catalog-item--active');
+                        activeButton = button;
+                    }
+                    updateQueryString(firstApi.id);
+                }
+            }
+        }
+
+        localDocInput.addEventListener('change', event => {
+            const file = event.target.files[0];
+            if (!file) return;
+
+            const reader = new FileReader();
+            reader.onload = e => {
+                viewerTitle.textContent = file.name;
+                viewerMeta.innerHTML = '<span class="meta-item">Archivo cargado desde tu dispositivo</span>';
+
+                const content = e.target.result;
+                if (file.name.match(/\.(md|markdown)$/i)) {
+                    docContent.innerHTML = marked.parse(content);
+                } else if (file.name.match(/\.(html|htm)$/i)) {
+                    const parser = new DOMParser();
+                    const parsed = parser.parseFromString(content, 'text/html');
+                    docContent.innerHTML = parsed.body ? parsed.body.innerHTML : content;
+                } else {
+                    docContent.innerHTML = '<p class="error-state">Formato no soportado. Utiliza archivos .md o .html.</p>';
+                }
+
+                if (activeButton) {
+                    activeButton.classList.remove('catalog-item--active');
+                    activeButton = null;
+                }
+
+                const params = new URLSearchParams(window.location.search);
+                params.delete('doc');
+                const query = params.toString();
+                if (history.replaceState) {
+                    const suffix = query ? `?${query}` : '';
+                    history.replaceState(null, '', `${window.location.pathname}${suffix}`);
+                }
+            };
+            reader.readAsText(file);
+        });
+
+        createCatalog();
+        handleInitialLoad();
+    </script>
+</body>
 </html>

--- a/styles.css
+++ b/styles.css
@@ -336,3 +336,395 @@ footer {
         margin-left: 250px;
     }
 }
+/* ==============================
+   Centro de Documentación (nuevo diseño)
+   ============================== */
+.docs-body {
+    background-color: #f7f8fa;
+    color: #1f2933;
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+}
+
+.docs-header {
+    position: sticky;
+    top: 0;
+    z-index: 10;
+    background-color: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 1.25rem clamp(1.5rem, 4vw, 4rem);
+}
+
+.docs-brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.brand-accent {
+    width: 10px;
+    height: 48px;
+    border-radius: 999px;
+    background: linear-gradient(180deg, #2563eb, #7c3aed);
+}
+
+.brand-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: #6b7280;
+}
+
+.brand-title {
+    font-size: clamp(1.35rem, 2vw, 1.75rem);
+    font-weight: 600;
+    color: #111827;
+}
+
+.docs-nav {
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.docs-nav a {
+    font-size: 0.95rem;
+    color: #4b5563;
+    text-decoration: none;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.docs-nav a:hover {
+    background-color: rgba(37, 99, 235, 0.08);
+    color: #1d4ed8;
+}
+
+.docs-layout {
+    display: grid;
+    grid-template-columns: minmax(240px, 320px) 1fr;
+    gap: 2.5rem;
+    padding: clamp(1.5rem, 4vw, 3rem) clamp(1.5rem, 4vw, 4rem);
+    max-width: 1400px;
+    margin: 0 auto;
+}
+
+.docs-sidebar {
+    background-color: #ffffff;
+    border: 1px solid #e5e7eb;
+    border-radius: 16px;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+}
+
+.sidebar-intro h2 {
+    font-size: 1.1rem;
+    margin-bottom: 0.35rem;
+    color: #1f2937;
+}
+
+.sidebar-intro p {
+    font-size: 0.95rem;
+    color: #6b7280;
+}
+
+.catalog {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.catalog-group {
+    border-top: 1px solid #f3f4f6;
+    padding-top: 1.25rem;
+}
+
+.catalog-group:first-of-type {
+    border-top: none;
+    padding-top: 0;
+}
+
+.catalog-group__header h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: #111827;
+}
+
+.catalog-group__header p {
+    font-size: 0.9rem;
+    color: #6b7280;
+    margin-top: 0.25rem;
+}
+
+.catalog-group__items {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 0.75rem;
+}
+
+.catalog-item {
+    width: 100%;
+    text-align: left;
+    background-color: #f9fafb;
+    border: 1px solid transparent;
+    border-radius: 12px;
+    padding: 0.85rem 1rem;
+    cursor: pointer;
+    transition: border-color 0.2s ease, background-color 0.2s ease, transform 0.2s ease;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.35rem 1rem;
+}
+
+.catalog-item:hover {
+    background-color: #eff6ff;
+    border-color: rgba(37, 99, 235, 0.35);
+}
+
+.catalog-item__title {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #1f2937;
+    grid-column: 1 / -1;
+}
+
+.catalog-item__summary {
+    font-size: 0.85rem;
+    color: #6b7280;
+}
+
+.catalog-item__format {
+    font-size: 0.75rem;
+    color: #1d4ed8;
+    align-self: center;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    background-color: rgba(37, 99, 235, 0.12);
+}
+
+.catalog-item--active {
+    background-color: #2563eb;
+    border-color: #1d4ed8;
+    color: #ffffff;
+    transform: translateY(-1px);
+}
+
+.catalog-item--active .catalog-item__title,
+.catalog-item--active .catalog-item__summary {
+    color: #ffffff;
+}
+
+.catalog-item--active .catalog-item__format {
+    background-color: rgba(255, 255, 255, 0.25);
+    color: #ffffff;
+}
+
+.docs-viewer {
+    background-color: #ffffff;
+    border-radius: 18px;
+    border: 1px solid #e5e7eb;
+    box-shadow: 0 18px 28px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    min-height: 70vh;
+}
+
+.viewer-toolbar {
+    padding: 1.75rem 2rem 1.5rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    border-bottom: 1px solid #f3f4f6;
+}
+
+.viewer-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.18em;
+    color: #9ca3af;
+    margin-bottom: 0.25rem;
+}
+
+.viewer-toolbar h2 {
+    font-size: clamp(1.1rem, 2vw, 1.5rem);
+    font-weight: 600;
+    color: #111827;
+}
+
+.upload-btn {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    background: linear-gradient(135deg, #2563eb, #7c3aed);
+    color: #ffffff;
+    font-size: 0.9rem;
+    font-weight: 500;
+    padding: 0.6rem 1.1rem;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+}
+
+.upload-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 28px rgba(37, 99, 235, 0.3);
+}
+
+.upload-btn input[type="file"] {
+    position: absolute;
+    inset: 0;
+    opacity: 0;
+    cursor: pointer;
+}
+
+.viewer-meta {
+    display: flex;
+    gap: 0.75rem;
+    padding: 0.75rem 2rem;
+    border-bottom: 1px solid #f3f4f6;
+    flex-wrap: wrap;
+}
+
+.meta-item {
+    font-size: 0.8rem;
+    color: #4b5563;
+    background-color: #f3f4f6;
+    border-radius: 999px;
+    padding: 0.35rem 0.85rem;
+}
+
+.viewer-content {
+    padding: 2rem;
+    overflow-y: auto;
+    flex: 1;
+    line-height: 1.7;
+    font-size: 0.97rem;
+}
+
+.viewer-content h1,
+.viewer-content h2,
+.viewer-content h3 {
+    color: #111827;
+    margin-top: 1.75rem;
+    margin-bottom: 0.75rem;
+}
+
+.viewer-content pre {
+    background-color: #0f172a;
+    color: #f8fafc;
+    padding: 1rem;
+    border-radius: 12px;
+    overflow-x: auto;
+    font-size: 0.9rem;
+}
+
+.viewer-content code {
+    font-family: "Fira Code", "SFMono-Regular", ui-monospace, monospace;
+    background-color: rgba(15, 23, 42, 0.08);
+    padding: 0.15rem 0.4rem;
+    border-radius: 6px;
+}
+
+.viewer-content pre code {
+    background: none;
+    padding: 0;
+}
+
+.viewer-content table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 1.5rem 0;
+}
+
+.viewer-content th,
+.viewer-content td {
+    border: 1px solid #e5e7eb;
+    padding: 0.75rem;
+    text-align: left;
+}
+
+.viewer-content th {
+    background-color: #f3f4f6;
+    font-weight: 600;
+}
+
+.viewer-content ul,
+.viewer-content ol {
+    margin: 1rem 0 1rem 1.25rem;
+}
+
+.empty-state {
+    color: #6b7280;
+}
+
+.loading {
+    color: #2563eb;
+}
+
+.error-state {
+    color: #b91c1c;
+}
+
+.docs-footer {
+    margin: 2rem auto 3rem;
+    max-width: 1400px;
+    padding: 0 2rem;
+    color: #6b7280;
+    font-size: 0.85rem;
+    text-align: center;
+}
+
+@media (max-width: 1024px) {
+    .docs-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .docs-sidebar {
+        position: static;
+        max-height: none;
+    }
+}
+
+@media (max-width: 640px) {
+    .docs-header {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 1.25rem;
+    }
+
+    .docs-nav {
+        width: 100%;
+        justify-content: flex-start;
+        gap: 1rem;
+        flex-wrap: wrap;
+    }
+
+    .viewer-toolbar {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .upload-btn {
+        width: 100%;
+        justify-content: center;
+    }
+
+    .viewer-meta {
+        padding: 0.75rem 1.5rem;
+    }
+
+    .viewer-content {
+        padding: 1.25rem 1.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- redesign the documentation page with a minimal hub layout, product catalog, and integrated viewer
- add dynamic loading for Markdown and HTML documentation plus local file uploads
- extend styling to support the new documentation experience and provide sample docs for multiple APIs

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69149288e5b88329827b2266c727781e)